### PR TITLE
Use environment variables for helper scripts configuration

### DIFF
--- a/HelperScripts/.env.example
+++ b/HelperScripts/.env.example
@@ -1,0 +1,13 @@
+# For Card_Template_matching_Example.py
+CARD_IMAGE_PATH=test/images/image.png
+GAME_STATE_IMAGE_PATH=test/images/deck.png
+
+# For frame-extract.py
+VIDEO_PATH=
+OUTPUT_DIR=dataset
+TARGET_RESOLUTION_WIDTH=480
+TARGET_RESOLUTION_HEIGHT=854
+CAPTURE_INTERVAL=5
+
+# For windows-capture-with required resolution.py
+WINDOW_NAME="BlueStacks App Player 1"

--- a/HelperScripts/Card_Template_matching_Example.py
+++ b/HelperScripts/Card_Template_matching_Example.py
@@ -1,11 +1,42 @@
 import cv2 as cv
 import numpy as np
 import time
+import os
+from dotenv import load_dotenv
 
-#game_image=cv.imread("test/images/2025-08-25-mob_11.jpg",cv.IMREAD_UNCHANGED)
-game_image=cv.imread("test/images/deck.png",cv.IMREAD_REDUCED_GRAYSCALE_2)
-knight=cv.imread("test/images/image.png", cv.IMREAD_REDUCED_GRAYSCALE_2)
-start=time.time()
+load_dotenv()
+
+# Get environment variables
+card_image_path = os.getenv("CARD_IMAGE_PATH")
+game_state_image_path = os.getenv("GAME_STATE_IMAGE_PATH")
+
+# Validate environment variables
+if not card_image_path or not game_state_image_path:
+    print("Error: Please set CARD_IMAGE_PATH and GAME_STATE_IMAGE_PATH in your .env file.")
+    exit()
+
+# Check if files exist
+if not os.path.exists(card_image_path):
+    print(f"Error: Card image not found at '{card_image_path}'")
+    exit()
+if not os.path.exists(game_state_image_path):
+    print(f"Error: Game state image not found at '{game_state_image_path}'")
+    exit()
+
+
+# Load images using paths from .env
+game_image = cv.imread(game_state_image_path, cv.IMREAD_REDUCED_GRAYSCALE_2)
+knight = cv.imread(card_image_path, cv.IMREAD_REDUCED_GRAYSCALE_2)
+
+# Check if images loaded correctly
+if game_image is None:
+    print(f"Error: Could not load game state image from '{game_state_image_path}'")
+    exit()
+if knight is None:
+    print(f"Error: Could not load card image from '{card_image_path}'")
+    exit()
+
+start = time.time()
 result= cv.matchTemplate(game_image, knight, cv.TM_CCOEFF_NORMED)
 end=time.time()
 duration_ms = (end - start) * 1000

--- a/HelperScripts/frame-extract.py
+++ b/HelperScripts/frame-extract.py
@@ -3,6 +3,7 @@ import os
 import math
 from concurrent.futures import ThreadPoolExecutor
 import threading
+from dotenv import load_dotenv
 
 def save_frame_worker(frame_data):
     """Worker function to save a frame with resizing"""
@@ -131,22 +132,33 @@ def extract_frames(video_path, output_folder, interval_seconds=5, target_resolut
 
 # --- HOW TO USE ---
 if __name__ == '__main__':
+    load_dotenv()
 
-    input_video = input("Enter the path to your video file: ")
+    # 1. Get configuration from environment variables
+    input_video = os.getenv("VIDEO_PATH")
+    output_dir = os.getenv("OUTPUT_DIR", "dataset")  # Default to "dataset"
+    capture_interval = int(os.getenv("CAPTURE_INTERVAL", 5))
+    target_width = int(os.getenv("TARGET_RESOLUTION_WIDTH", 480))
+    target_height = int(os.getenv("TARGET_RESOLUTION_HEIGHT", 854))
 
-    # 2. Set the folder where you want to save the images
-    output_dir = "dataset"
+    # 2. Validate required environment variables
+    if not input_video:
+        print("Error: VIDEO_PATH environment variable not set. Please create a .env file and set it.")
+        exit()
 
-    # 3. Set the interval in seconds (e.g., 5 for one frame every 5 seconds)
-    capture_interval = int(input("Enter the frame capture interval in seconds (e.g., 5): "))
-    if capture_interval <= 0 or capture_interval > 3600:
-        print("Invalid interval. Using default of 5 seconds.")
+    # 3. Validate capture interval
+    if not 0 < capture_interval <= 3600:
+        print(f"Invalid capture interval: {capture_interval}. Must be between 1 and 3600 seconds.")
+        print("Using default of 5 seconds.")
         capture_interval = 5
 
-    # Run the function - 854x480 is proper 16:9 aspect ratio
+    # 4. Run the extraction function
+    target_resolution = (target_width, target_height)
     try:
-        extract_frames(input_video, output_dir, capture_interval, target_resolution=(480,854), max_workers=32)
+        extract_frames(input_video, output_dir, capture_interval, target_resolution=target_resolution, max_workers=32)
     except KeyboardInterrupt:
-        print("Extraction interrupted by user.")
+        print("\nExtraction interrupted by user.")
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
     finally:
-        print("Cleanup resources if needed.")
+        print("Script finished.")

--- a/HelperScripts/requirements.txt
+++ b/HelperScripts/requirements.txt
@@ -1,0 +1,1 @@
+python-dotenv

--- a/HelperScripts/windows-capture-with required resolution.py
+++ b/HelperScripts/windows-capture-with required resolution.py
@@ -1,21 +1,36 @@
 from windows_capture import WindowsCapture, Frame, InternalCaptureControl
 import cv2 as cv
 import numpy as np
+import os
+from dotenv import load_dotenv
 
+load_dotenv()
+
+# --- Configuration ---
 # Crop settings - adjust these values manually
-CROP_LEFT = 657  # pixels to crop from left
-CROP_RIGHT = 657  # pixels to crop from right
-TARGET_WIDTH = 480
-TARGET_HEIGHT = 854
+CROP_LEFT = int(os.getenv("CROP_LEFT", 657))
+CROP_RIGHT = int(os.getenv("CROP_RIGHT", 657))
+TARGET_WIDTH = int(os.getenv("TARGET_WIDTH", 480))
+TARGET_HEIGHT = int(os.getenv("TARGET_HEIGHT", 854))
+WINDOW_NAME = os.getenv("WINDOW_NAME")
 
-# Every Error From on_closed and on_frame_arrived Will End Up Here
+# --- Validation ---
+if not WINDOW_NAME:
+    print("Error: WINDOW_NAME is not set in the .env file.")
+    exit()
 
-capture = WindowsCapture(
-    cursor_capture=None,
-    draw_border=None,
-    monitor_index=None,
-    window_name="BlueStacks App Player 1",
-)
+# --- Capture Initialization ---
+try:
+    capture = WindowsCapture(
+        cursor_capture=None,
+        draw_border=None,
+        monitor_index=None,
+        window_name=WINDOW_NAME,
+    )
+except Exception as e:
+    print(f"Error initializing window capture: {e}")
+    print(f"Please ensure a window with the name '{WINDOW_NAME}' is open.")
+    exit()
 
 
 @capture.event


### PR DESCRIPTION
This commit refactors the helper scripts to use environment variables for configuration instead of hardcoded values or interactive prompts.

A `.env.example` file has been added to `HelperScripts` to document the required environment variables.

The following scripts have been updated:
- `Card_Template_matching_Example.py`: now uses `CARD_IMAGE_PATH` and `GAME_STATE_IMAGE_PATH`.
- `frame-extract.py`: now uses `VIDEO_PATH`, `OUTPUT_DIR`, `TARGET_RESOLUTION_WIDTH`, `TARGET_RESOLUTION_HEIGHT`, and `CAPTURE_INTERVAL`. The default resolution is set to 480x854.
- `windows-capture-with required resolution.py`: now uses `WINDOW_NAME`.

A `requirements.txt` file has been added to `HelperScripts` with the `python-dotenv` dependency.